### PR TITLE
Plot Function Additoin + Bug Fixes - Remove Assert due to Codacy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 scipy
 pandas
 statsmodels
+matplotlib


### PR DESCRIPTION
    A plot function has been added. the function only takes the data and the anomaly return dict to generate a simple plot and return to user in the dict.

    When using pandas dataframes as data, and dtype was int64, it was generating error in the block where dtype is checked against int and float. So I added a check against 'int64' as well

    For the cases where the datetime have gaps in the middle, the code would take data which sometimes will be less than the num_obs_samples due to break and will generate assertions. I have handled it by ignoring the samples wherever this condition is not met. This is a debatable approach, however, this does remove the assertion errors as other anomalies are still detected.
